### PR TITLE
:tada: Allow loading scripts without manually awaiting them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "aligned"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,7 +643,7 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1326,25 +1332,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.32"
+name = "futures"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-lite"
@@ -1361,9 +1394,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1371,20 +1404,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-task"
-version = "0.3.32"
+name = "futures-sink"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+
+[[package]]
+name = "futures-task"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -1585,6 +1626,12 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -2166,6 +2213,7 @@ dependencies = [
  "bstr",
  "either",
  "erased-serde",
+ "futures-util",
  "libc",
  "mlua-sys",
  "num-traits",
@@ -2493,6 +2541,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2759,6 +2831,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -3098,11 +3183,13 @@ dependencies = [
  "emscripten-functions",
  "emscripten-val",
  "fontdue",
+ "futures",
  "image",
  "libloading 0.9.0",
  "nalgebra",
  "noise",
  "num-traits",
+ "ouroboros",
  "regex",
  "serde_json",
  "symphonia",
@@ -4554,7 +4641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -4565,7 +4652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "prettyplease",
  "syn",
@@ -4643,6 +4730,12 @@ name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,12 +50,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aliasable"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
-
-[[package]]
 name = "aligned"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,7 +637,7 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -1629,12 +1623,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -2541,30 +2529,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ouroboros"
-version = "0.18.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
-dependencies = [
- "aliasable",
- "ouroboros_macro",
- "static_assertions",
-]
-
-[[package]]
-name = "ouroboros_macro"
-version = "0.18.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "proc-macro2-diagnostics",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2831,19 +2795,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proc-macro2-diagnostics"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
- "yansi",
 ]
 
 [[package]]
@@ -3189,7 +3140,6 @@ dependencies = [
  "nalgebra",
  "noise",
  "num-traits",
- "ouroboros",
  "regex",
  "serde_json",
  "symphonia",
@@ -4641,7 +4591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "wit-parser",
 ]
 
@@ -4652,7 +4602,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "indexmap",
  "prettyplease",
  "syn",
@@ -4730,12 +4680,6 @@ name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
-
-[[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -418,9 +418,9 @@ multiple files.
 
 ## Scripts as Resources
 
-To run another `.luau` file, it needs to be loaded as a resource. You can load it using the `loadScript`.
-Loading resources is not instant. The system needs to wait the resources to become ready. Meanwhile, you can
-show a loading screen or something else.
+To run another `.luau` file, you can use `require`.
+Loading resources is not instant. The system needs to wait the resources to become ready and shows a loading screen in the meantime.
+You can use `loader.loadScript` to schedule the loading of a script and check if it is ready or not.
 
 Example:
 
@@ -439,13 +439,14 @@ end)
 
 -- You can also check at any point if a resource is ready or not:
 if otherScriptResource:isReady() then
-    -- OK
+    local otherScript = require("other_script.luau")
+    -- OK, I can now use functions and variables defined inside other_script.luau
 end
 ```
 
 ## Using modules
 
-Once a script is loaded, all future calls to `loadScript` with the same path will return a handle to the same resource and are instant.
+Once a script is loaded, all calls to `require` with the same path will return a handle to the same script and are instant.
 
 By default all global variables and functions are shared between files.
 This has pros and cons:
@@ -459,7 +460,6 @@ Because of that, we recommend doing the following (this is just a recommendation
 
 - Keep functions local whenever possible using the `local function(...) function_content() end` syntax.
 - Put the functions and variables exported by a module in a table that gets returned.
-- When calling `loadScript`, pass the require call as the second argument to gather the exports of the script with proper types.
 - Never use globals.
 
 There is a simple example with 2 files: `helper.luau` and `main.luau`.
@@ -487,28 +487,12 @@ return module -- return for the module to make it available
 const debug = require('@vectarine/debug')
 const loader = require('@vectarine/loader')
 
---- We use the import 'technique'
-local helperResource, Helper = loader.loadScript("scripts/helper.luau", require("helper.luau"))
-
---- loader.loadScript is what actually executes `helper.luau`.
---- require() returns an empty table, but is properly typed.
---- When a table is passed as the second argument to loadScript, it is filled with the exports of the script.
---- This gives the impression that require() returns the exports of the script, but it does not.
-
---- Note that the Helper variable is still empty until the resource is ready.
-
---- Also, note that `helper.luau` is only executed once. If you rerun loadScript, you'll get a handle to the same resource.
---- However, Helper will always be filled with the latest exports of the script, even if it is reloaded.
---- This only works if the script returns a table, otherwise, this is ignored.
+-- require pauses execution until the module is loaded and returns the module table
+local helper = require("./helper")
 
 function Update()
-    if !helperResource.isReady() then
-        -- Don't forget to add a loading state to indicate that the script is not ready yet!
-        debug.fprint("Loading helper.luau...")
-        return
-    end
     -- The script is loaded and ready for use!
-    debug.fprint("adding things: ", Helper.add_things(3+1))
+    debug.fprint("adding things: ", helper.add_things(3+1))
 end
 ```
 

--- a/docs/website/src/content/docs/guides/a-guided-tour.mdx
+++ b/docs/website/src/content/docs/guides/a-guided-tour.mdx
@@ -418,9 +418,11 @@ multiple files.
 
 ### Scripts as Resources
 
-To run another `.luau` file, it needs to be loaded as a resource. You can load it using the `loadScript`.
-Loading resources is not instant. The system needs to wait the resources to become ready. Meanwhile, you can
-show a loading screen or something else.
+## Scripts as Resources
+
+To run another `.luau` file, you can use `require`.
+Loading resources is not instant. The system needs to wait the resources to become ready and shows a loading screen in the meantime.
+You can use `loader.loadScript` to schedule the loading of a script and check if it is ready or not.
 
 Example:
 
@@ -438,14 +440,16 @@ end)
 
 -- You can also check at any point if a resource is ready or not:
 if otherScriptResource:isReady() then
-    -- OK
-end`;
+    local otherScript = require("other_script.luau")
+    -- OK, I can now use functions and variables defined inside other_script.luau
+end
+`;
 
 <Code lang="luau" code={tourLoaderScript} />
 
 ### Using modules
 
-Once a script is loaded, all future calls to `loadScript` with the same path will return a handle to the same luau table and are instant.
+Once a script is loaded, all future calls to `require` with the same path will return a handle to the same luau table and are instant.
 
 By default all global variables and functions are shared between files.
 This has pros and cons:
@@ -459,7 +463,6 @@ Because of that, we recommend doing the following (this is just a recommendation
 
 - Use `loader.init() or {}` to create a table to hold the exports of your module and return this table at the end of your script.
 - Keep functions local whenever possible using the `local function(...) function_content() end` syntax.
-- When calling `loadScript`, pass the require call as the second argument to gather the exports of the script with proper types.
 - Never use globals.
 
 There is a simple example with 2 files: `helper.luau` and `main.luau`.
@@ -481,28 +484,11 @@ return module -- return for the module to make it available`;
 
 export const tourMainModule = `-- main.luau
 const debug = require('@vectarine/debug')
-const loader = require('@vectarine/loader')
 
---- We use the import 'technique'
-const helperResource, helper = loader.loadScript("scripts/helper.luau", require("helper.luau"))
-
---- loader.loadScript is what actually executes \`helper.luau\`.
---- require() returns an empty table, but is properly typed.
---- When a table is passed as the second argument to loadScript, it is filled with the exports of the script.
---- This gives the impression that require() returns the exports of the script, but it does not.
-
---- Note that the helper variable is still empty until the resource is ready.
-
---- Also, note that \`helper.luau\` is only executed once. If you rerun loadScript, you'll get a handle to the same resource.
---- However, helper will always be filled with the latest exports of the script, even if it is reloaded.
---- This only works if the script returns a table, otherwise, this is ignored.
+-- require pauses execution until the module is loaded and returns the module table
+const helper = require("./helper")
 
 function Update()
-    if !helperResource.isReady() then
-        -- Don't forget to add a loading state to indicate that the script is not ready yet!
-        debug.fprint("Loading helper.luau...")
-        return
-    end
     -- The script is loaded and ready for use!
     debug.fprint("adding things: ", helper.add_things(3+1))
 end`;

--- a/docs/website/src/content/docs/guides/understanding-hotreloading.mdx
+++ b/docs/website/src/content/docs/guides/understanding-hotreloading.mdx
@@ -26,7 +26,7 @@ Let's consider the following example:
 
 export const mainLuau1 = `const loader = require("@vectarine/loader")
 const debug = require("@vectarine/debug")
-const res, other = loader.loadScript("scripts/other.luau", require("other.luau"))
+const res, other = loader.loadScript("scripts/other.luau", {} :: any)
 
 local value = nil
 if res:isReady() then

--- a/gallery/Platformer/scripts/game.luau
+++ b/gallery/Platformer/scripts/game.luau
@@ -24,11 +24,9 @@ local vec = require("@vectarine/vec")
 local vec4 = require("@vectarine/vec4")
 
 -- Script resources
-local fRes, f = loader.loadScript("scripts/f.luau", require("./f"))
-local InteractableRes, Interactable = loader.loadScript("scripts/interactable.luau", require("./interactable"))
-local InteractableTypes = require("./interactable")
-local WorldRes, World = loader.loadScript("scripts/world.luau", require("./world"))
-local WorldTypes = require("./world")
+local Interactable = require("./interactable")
+local World = require("./world")
+local f = require("./f")
 
 -- Constants
 local FOREGROUND_LAYER = 2
@@ -88,9 +86,9 @@ local world = physics.newWorld2(vec.ZERO2, camera)
 local factor = vec.V2(0.1, -0.1)
 local offset = vec.V2(-1, 1)
 
-local infiniteWorld: WorldTypes.IWorld
+local infiniteWorld: World.IWorld
 
-local interactibleManager: InteractableTypes.InteractableManager
+local interactibleManager: Interactable.InteractableManager
 
 function makePlayer()
 	-- By default, we make the player collider way too big.
@@ -183,17 +181,12 @@ if areResourcesLoaded.loaded then
 end
 
 function Update(deltaTime: number)
-	if
-		graphics.drawSplashScreenIfNeeded({
-			tiles_tiles,
-			tiles_image,
-			fRes,
-			InteractableRes,
-			WorldRes,
-			icons_tiles,
-			icons_image,
-		})
-	then
+	if graphics.drawSplashScreenIfNeeded({
+		tiles_tiles,
+		tiles_image,
+		icons_tiles,
+		icons_image,
+	}) then
 		return
 	end
 	if not areResourcesLoaded.loaded then

--- a/gallery/Sokoban/scripts/game.luau
+++ b/gallery/Sokoban/scripts/game.luau
@@ -20,11 +20,8 @@ local persist = require("@vectarine/persist")
 local vec = require("@vectarine/vec")
 local vec4 = require("@vectarine/vec4")
 
-local worldRes, worldManager = loader.loadScript("scripts/world.luau", require("./world"))
-local worldTypes = require("./world")
-
-local signRes, sign = loader.loadScript("scripts/sign.luau", require("./sign"))
-local signTypes = require("./sign")
+local sign = require("./sign")
+local worldManager = require("./world")
 
 local tiles_tiles = loader.loadTileset("textures/tileset.tsx")
 local tiles_image = loader.loadImage("textures/tileset.png", false)
@@ -39,8 +36,8 @@ local areResourcesLoaded = persist.onReload({ loaded = false }, "areResourcesLoa
 local gameCamera = persist.onReload(camera.new(), "camera")
 local ZOOM_LEVEL = 0.12 -- This factor is choosen so that you can see the current room + about 1.5 tile of the surrounding ones
 
-local world: worldTypes.IWorld
-local signManager: signTypes.SignManager
+local world: worldManager.IWorld
+local signManager: sign.SignManager
 
 -- You can explore the level freely by setting noclip to true from the watcher.
 local debugging = persist.onReload({
@@ -70,8 +67,6 @@ function Update(deltaTime: number)
 	if graphics.drawSplashScreenIfNeeded({
 		tiles_tiles,
 		tiles_image,
-		worldRes,
-		signRes,
 	}) then
 		return
 	end

--- a/luau-api/loader.luau
+++ b/luau-api/loader.luau
@@ -10,7 +10,9 @@ local Tile = require("@vectarine/tile")
 --- Functions to load external resources like images, scripts, fonts, shaders, audio, etc.
 local module = {}
 
---- Loads and runs a Lua file at the given path.$
+--- Similar to require(), but it is synchronous and will return an empty table if the script has not been loaded yet.
+--- Usually, you should use require() unless you want to load your scripts asynchronously, if you have a lot of scripts.
+---
 --- For typing purposes, you can pass a table as the second argument, but this has no runtime effect.
 --- The return value is a ScriptResource and the module table returned by the script.
 ---

--- a/luau-api/loader.luau
+++ b/luau-api/loader.luau
@@ -24,7 +24,7 @@ local module = {}
 --- ```
 --- @param path For example scripts/monster.lua
 --- @param type_hint A table to hint the type of the module returned by the script. This has no runtime effect.
-function module.loadScript<T>(path: string, type_hint: T): (Res.ScriptResource, T)
+function module.loadScript<T>(path: string, type_hint: T?): (Res.ScriptResource, T)
 	error("Implemented in native code")
 end
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -16,7 +16,6 @@ symphonia = { version = "0.6.0", features = ["opt-simd", "all-meta", "all-codecs
 num-traits = "0.2.19"
 nalgebra = "0.34.1"
 vectarine-plugin-sdk = { path = "../vectarine-plugin-sdk" }
-ouroboros = "0.18.5"
 futures = "0.3.33"
 
 [target.'cfg(not(target_os = "emscripten"))'.dependencies]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -16,6 +16,8 @@ symphonia = { version = "0.6.0", features = ["opt-simd", "all-meta", "all-codecs
 num-traits = "0.2.19"
 nalgebra = "0.34.1"
 vectarine-plugin-sdk = { path = "../vectarine-plugin-sdk" }
+ouroboros = "0.18.5"
+futures = "0.3.33"
 
 [target.'cfg(not(target_os = "emscripten"))'.dependencies]
 libloading = "0.9.0"

--- a/runtime/src/async_handler.rs
+++ b/runtime/src/async_handler.rs
@@ -10,19 +10,17 @@ use futures::future::Either;
 use crate::console::{print_err, print_warn};
 use crate::game_resource::{self, Resource, ResourceManager, Status};
 use crate::lua_env::{LuaHandle, print_lua_error_from_error};
-use ouroboros::self_referencing;
 use vectarine_plugin_sdk::mlua;
 use vectarine_plugin_sdk::mlua::function::AsyncCallFuture;
 
 pub struct DummyWaker;
-
+#[allow(clippy::manual_noop_waker)]
 impl Wake for DummyWaker {
-    fn wake(self: Arc<Self>) {
-        // In a fully featured custom runtime, this would push your future
-        // to a "ready" queue to be polled again.
-        // For a simple frame-by-frame game loop, a no-op is perfectly fine.
-    }
+    // The frame-by-frame polling wakes the futures as needed.
+    fn wake(self: Arc<Self>) {}
 }
+
+type FutureQueue = Vec<Pin<Box<dyn Future<Output = Result<(), mlua::Error>>>>>;
 
 /// Turn a value of type T into a future that is immediately ready with that value.
 pub fn futurify<T>(t: T) -> impl Future<Output = T> {
@@ -42,7 +40,7 @@ impl<T: Resource + 'static> Future for ResourceFuture<T> {
         let id = self
             .manager
             .get_id_by_path(&self.resource_path)
-            .expect("Tkt");
+            .expect("A resource future was created for a resource that was never scheduled to be loaded. This is a bug in make_resource_future.");
         let resource_holder = self.manager.get_holder_by_id(id);
         match resource_holder.get_status() {
             Status::Loading => std::task::Poll::Pending,
@@ -69,8 +67,8 @@ pub fn make_resource_future<T: Resource + 'static>(
 ) -> impl Future<Output = Option<Rc<T>>> {
     let resource_path =
         game_resource::resolve_dot_relative_paths(&resource_path, loading_cause_path);
-    let id_opt = manager.get_id_by_path(&resource_path);
-    if let Some(id) = id_opt {
+    let maybe_resource_id = manager.get_id_by_path(&resource_path);
+    if let Some(id) = maybe_resource_id {
         let holder = manager.get_holder_by_id(id);
         if holder.get_status() == Status::Loaded {
             if let Ok(res) = holder.get_underlying_resource::<T>() {
@@ -81,13 +79,13 @@ pub fn make_resource_future<T: Resource + 'static>(
         } else if let Status::Error(_) = holder.get_status() {
             return Either::Left(std::future::ready(None));
         }
-    } else {
-        manager.schedule_load_script_resource(
-            resource_path.as_path(),
-            loading_cause_path,
-            target_table,
-        );
     }
+
+    manager.schedule_load_script_resource(
+        resource_path.as_path(),
+        loading_cause_path,
+        target_table,
+    );
     Either::Right(ResourceFuture {
         manager,
         resource_path,
@@ -95,13 +93,9 @@ pub fn make_resource_future<T: Resource + 'static>(
     })
 }
 
-#[self_referencing]
 struct AsyncHandlerInternal {
-    future_queue: Vec<Pin<Box<dyn Future<Output = Result<(), mlua::Error>>>>>,
-    waker: Waker,
-    #[borrows(waker)]
-    #[not_covariant]
-    ctx: Context<'this>,
+    future_queue: FutureQueue,
+    ctx: Context<'static>,
 }
 
 /// A simple single-threaded async runtime for Lua coroutines.
@@ -117,14 +111,12 @@ impl Default for AsyncLuaHandle {
 
 impl AsyncLuaHandle {
     pub fn new() -> Self {
-        let waker = Waker::from(Arc::new(DummyWaker));
-        let internal = AsyncHandlerInternalBuilder {
+        let internal = AsyncHandlerInternal {
             future_queue: Vec::new(),
-            waker,
-            ctx_builder: |w| Context::from_waker(w),
-        }
-        .build();
-
+            // If we used a custom waker, we'd need a crate like ouroboros as the waker would we stored in this internal struct too (and would thus be self-referential).
+            // However, as we do the waking ourselves, this is not needed.
+            ctx: Context::from_waker(Waker::noop()),
+        };
         AsyncLuaHandle { internal }
     }
 
@@ -136,7 +128,7 @@ impl AsyncLuaHandle {
         lua_handle: &Rc<LuaHandle>,
         mut future: Pin<Box<dyn Future<Output = Result<(), mlua::Error>>>>,
     ) -> bool {
-        let result = self.internal.with_ctx_mut(|ctx| future.as_mut().poll(ctx));
+        let result = future.as_mut().poll(&mut self.internal.ctx);
 
         match result {
             std::task::Poll::Ready(Ok(_)) => true,
@@ -146,16 +138,14 @@ impl AsyncLuaHandle {
                 true
             }
             std::task::Poll::Pending => {
-                self.internal.with_future_queue_mut(|queue| {
-                    queue.push(future);
-                });
+                self.internal.future_queue.push(future);
                 false
             }
         }
     }
 
     pub fn are_futures_pending(&self) -> bool {
-        self.internal.with_future_queue(|queue| !queue.is_empty())
+        !self.internal.future_queue.is_empty()
     }
 
     /// Schedule the lua coroutine to be executed at a later time.
@@ -169,7 +159,7 @@ impl AsyncLuaHandle {
         print_warning_if_pending: bool,
     ) {
         let mut pinned = Box::pin(future);
-        let polled = self.internal.with_ctx_mut(|ctx| pinned.as_mut().poll(ctx));
+        let polled = pinned.as_mut().poll(&mut self.internal.ctx);
         match polled {
             std::task::Poll::Ready(Ok(_)) => {}
             std::task::Poll::Ready(Err(err)) => {
@@ -188,21 +178,17 @@ impl AsyncLuaHandle {
     /// This function needs to be called regularly to update running futures, usually once per frame.
     /// Do not call it directly, call `LuaHandle::poll_pending_futures` instead.
     pub fn poll_pending_futures(&mut self, lua_handle: &Rc<LuaHandle>) {
-        self.internal.with_mut(|fields| {
-            fields.future_queue.retain_mut(|future| {
-                let polled = future.as_mut().poll(fields.ctx);
-                match polled {
-                    std::task::Poll::Ready(Ok(_)) => false,
-                    std::task::Poll::Ready(Err(err)) => {
-                        print_err(
-                            "Something when wrong during the execution of a future.".to_string(),
-                        );
-                        print_lua_error_from_error(lua_handle, &err);
-                        false
-                    }
-                    std::task::Poll::Pending => true,
+        self.internal.future_queue.retain_mut(|future| {
+            let polled = future.as_mut().poll(&mut self.internal.ctx);
+            match polled {
+                std::task::Poll::Ready(Ok(_)) => false,
+                std::task::Poll::Ready(Err(err)) => {
+                    print_err("Something when wrong during the execution of a future.".to_string());
+                    print_lua_error_from_error(lua_handle, &err);
+                    false
                 }
-            });
+                std::task::Poll::Pending => true,
+            }
         });
     }
 }

--- a/runtime/src/async_handler.rs
+++ b/runtime/src/async_handler.rs
@@ -1,0 +1,208 @@
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::task::{Context, Wake, Waker};
+
+use futures::future::Either;
+
+use crate::console::{print_err, print_warn};
+use crate::game_resource::{self, Resource, ResourceManager, Status};
+use crate::lua_env::{LuaHandle, print_lua_error_from_error};
+use ouroboros::self_referencing;
+use vectarine_plugin_sdk::mlua;
+use vectarine_plugin_sdk::mlua::function::AsyncCallFuture;
+
+pub struct DummyWaker;
+
+impl Wake for DummyWaker {
+    fn wake(self: Arc<Self>) {
+        // In a fully featured custom runtime, this would push your future
+        // to a "ready" queue to be polled again.
+        // For a simple frame-by-frame game loop, a no-op is perfectly fine.
+    }
+}
+
+/// Turn a value of type T into a future that is immediately ready with that value.
+pub fn futurify<T>(t: T) -> impl Future<Output = T> {
+    std::future::ready(t)
+}
+
+struct ResourceFuture<T: Resource + 'static> {
+    manager: Rc<ResourceManager>,
+    resource_path: PathBuf,
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T: Resource + 'static> Future for ResourceFuture<T> {
+    type Output = Option<Rc<T>>;
+
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> std::task::Poll<Self::Output> {
+        let id = self
+            .manager
+            .get_id_by_path(&self.resource_path)
+            .expect("Tkt");
+        let resource_holder = self.manager.get_holder_by_id(id);
+        match resource_holder.get_status() {
+            Status::Loading => std::task::Poll::Pending,
+            Status::Unloaded => std::task::Poll::Pending,
+            Status::Error(_) => std::task::Poll::Ready(None),
+            Status::Loaded => {
+                let res = resource_holder.get_underlying_resource::<T>();
+                if let Ok(res) = res {
+                    std::task::Poll::Ready(Some(res))
+                } else {
+                    std::task::Poll::Ready(None)
+                }
+            }
+        }
+    }
+}
+
+/// Create a future that is resolved when the resource provided is loaded / in an error state.
+pub fn make_resource_future<T: Resource + 'static>(
+    manager: Rc<ResourceManager>,
+    loading_cause_path: Option<&Path>,
+    target_table: vectarine_plugin_sdk::mlua::Table,
+    resource_path: PathBuf,
+) -> impl Future<Output = Option<Rc<T>>> {
+    let resource_path =
+        game_resource::resolve_dot_relative_paths(&resource_path, loading_cause_path);
+    let id_opt = manager.get_id_by_path(&resource_path);
+    if let Some(id) = id_opt {
+        let holder = manager.get_holder_by_id(id);
+        if holder.get_status() == Status::Loaded {
+            if let Ok(res) = holder.get_underlying_resource::<T>() {
+                return Either::Left(std::future::ready(Some(res)));
+            } else {
+                return Either::Left(std::future::ready(None));
+            }
+        } else if let Status::Error(_) = holder.get_status() {
+            return Either::Left(std::future::ready(None));
+        }
+    } else {
+        manager.schedule_load_script_resource(
+            resource_path.as_path(),
+            loading_cause_path,
+            target_table,
+        );
+    }
+    Either::Right(ResourceFuture {
+        manager,
+        resource_path,
+        _marker: std::marker::PhantomData,
+    })
+}
+
+#[self_referencing]
+struct AsyncHandlerInternal {
+    future_queue: Vec<Pin<Box<dyn Future<Output = Result<(), mlua::Error>>>>>,
+    waker: Waker,
+    #[borrows(waker)]
+    #[not_covariant]
+    ctx: Context<'this>,
+}
+
+/// A simple single-threaded async runtime for Lua coroutines.
+pub struct AsyncLuaHandle {
+    internal: AsyncHandlerInternal,
+}
+
+impl Default for AsyncLuaHandle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AsyncLuaHandle {
+    pub fn new() -> Self {
+        let waker = Waker::from(Arc::new(DummyWaker));
+        let internal = AsyncHandlerInternalBuilder {
+            future_queue: Vec::new(),
+            waker,
+            ctx_builder: |w| Context::from_waker(w),
+        }
+        .build();
+
+        AsyncLuaHandle { internal }
+    }
+
+    /// Schedule a future to be executed at a later time.
+    /// Errors produced by the future will be printed to the console.
+    /// If the future is ready, returns true.
+    pub fn schedule_future(
+        &mut self,
+        lua_handle: &Rc<LuaHandle>,
+        mut future: Pin<Box<dyn Future<Output = Result<(), mlua::Error>>>>,
+    ) -> bool {
+        let result = self.internal.with_ctx_mut(|ctx| future.as_mut().poll(ctx));
+
+        match result {
+            std::task::Poll::Ready(Ok(_)) => true,
+            std::task::Poll::Ready(Err(err)) => {
+                print_err("Something when wrong during the execution of a future.".to_string());
+                print_lua_error_from_error(lua_handle, &err);
+                true
+            }
+            std::task::Poll::Pending => {
+                self.internal.with_future_queue_mut(|queue| {
+                    queue.push(future);
+                });
+                false
+            }
+        }
+    }
+
+    pub fn are_futures_pending(&self) -> bool {
+        self.internal.with_future_queue(|queue| !queue.is_empty())
+    }
+
+    /// Schedule the lua coroutine to be executed at a later time.
+    /// Errors produced by the coroutine will be printed to the console.
+    pub fn execute_frame(
+        &mut self,
+        lua_handle: &Rc<LuaHandle>,
+        future: AsyncCallFuture<()>,
+        // If true, a warning will be printed if the future is not ready yet.
+        // Typically, during calls to update, async calls should be ready, and if they are not, rendering got interrupted.
+        print_warning_if_pending: bool,
+    ) {
+        let mut pinned = Box::pin(future);
+        let polled = self.internal.with_ctx_mut(|ctx| pinned.as_mut().poll(ctx));
+        match polled {
+            std::task::Poll::Ready(Ok(_)) => {}
+            std::task::Poll::Ready(Err(err)) => {
+                print_err("Something when wrong during the execution of a future.".to_string());
+                print_lua_error_from_error(lua_handle, &err);
+            }
+            std::task::Poll::Pending => {
+                if print_warning_if_pending {
+                    print_warn("An asynchronous function was called during a critical section. This can cause half-drawn frames to render.".to_string());
+                }
+                self.schedule_future(lua_handle, pinned);
+            }
+        }
+    }
+
+    /// This function needs to be called regularly to update running futures, usually once per frame.
+    /// Do not call it directly, call `LuaHandle::poll_pending_futures` instead.
+    pub fn poll_pending_futures(&mut self, lua_handle: &Rc<LuaHandle>) {
+        self.internal.with_mut(|fields| {
+            fields.future_queue.retain_mut(|future| {
+                let polled = future.as_mut().poll(fields.ctx);
+                match polled {
+                    std::task::Poll::Ready(Ok(_)) => false,
+                    std::task::Poll::Ready(Err(err)) => {
+                        print_err(
+                            "Something when wrong during the execution of a future.".to_string(),
+                        );
+                        print_lua_error_from_error(lua_handle, &err);
+                        false
+                    }
+                    std::task::Poll::Pending => true,
+                }
+            });
+        });
+    }
+}

--- a/runtime/src/async_handler.rs
+++ b/runtime/src/async_handler.rs
@@ -7,7 +7,7 @@ use std::task::{Context, Wake, Waker};
 
 use futures::future::Either;
 
-use crate::console::{print_err, print_warn};
+use crate::console::print_warn;
 use crate::game_resource::{self, Resource, ResourceManager, Status};
 use crate::lua_env::{LuaHandle, print_lua_error_from_error};
 use vectarine_plugin_sdk::mlua;
@@ -40,7 +40,7 @@ impl<T: Resource + 'static> Future for ResourceFuture<T> {
         let id = self
             .manager
             .get_id_by_path(&self.resource_path)
-            .expect("A resource future was created for a resource that was never scheduled to be loaded. This is a bug in make_resource_future.");
+            .expect("A resource future was created for a resource that was never scheduled to be loaded. This might be a bug in make_resource_future.");
         let resource_holder = self.manager.get_holder_by_id(id);
         match resource_holder.get_status() {
             Status::Loading => std::task::Poll::Pending,
@@ -133,7 +133,6 @@ impl AsyncLuaHandle {
         match result {
             std::task::Poll::Ready(Ok(_)) => true,
             std::task::Poll::Ready(Err(err)) => {
-                print_err("Something when wrong during the execution of a future.".to_string());
                 print_lua_error_from_error(lua_handle, &err);
                 true
             }
@@ -163,7 +162,6 @@ impl AsyncLuaHandle {
         match polled {
             std::task::Poll::Ready(Ok(_)) => {}
             std::task::Poll::Ready(Err(err)) => {
-                print_err("Something when wrong during the execution of a future.".to_string());
                 print_lua_error_from_error(lua_handle, &err);
             }
             std::task::Poll::Pending => {
@@ -183,7 +181,6 @@ impl AsyncLuaHandle {
             match polled {
                 std::task::Poll::Ready(Ok(_)) => false,
                 std::task::Poll::Ready(Err(err)) => {
-                    print_err("Something when wrong during the execution of a future.".to_string());
                     print_lua_error_from_error(lua_handle, &err);
                     false
                 }

--- a/runtime/src/game.rs
+++ b/runtime/src/game.rs
@@ -326,6 +326,10 @@ impl Game {
             gl.disable(glow::DEPTH_TEST);
             // gl.enable(glow::SAMPLE_ALPHA_TO_COVERAGE); // Not needed for 2D.
             gl.enable(glow::MULTISAMPLE);
+
+            // If we don't clear and the game crashes, it looks weird.
+            gl.clear_color(0.0, 0.0, 0.0, 1.0);
+            gl.clear(glow::COLOR_BUFFER_BIT);
         }
 
         let plugin_interface = PluginInterface {

--- a/runtime/src/game.rs
+++ b/runtime/src/game.rs
@@ -369,6 +369,8 @@ impl Game {
                 // But if there are futures, we might need to wait for them to create the update function.
                 if !self.lua_env.lua_handle.are_futures_pending() {
                     print_warn("Update() function not found".to_string());
+                } else {
+                    // Manually draw a loading screen here (maybe with progress based on the number of pending futures).
                 }
             }
         }

--- a/runtime/src/game.rs
+++ b/runtime/src/game.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     graphics::batchdraw::BatchDraw2d,
     io::{fs::ReadOnlyFileSystem, process_events},
-    lua_env::{LuaEnvironment, print_lua_error_from_error},
+    lua_env::LuaEnvironment,
     metrics::{
         DRAW_CALL_METRIC_NAME, LUA_HEAP_SIZE_METRIC_NAME, LUA_SCRIPT_TIME_METRIC_NAME,
         MetricsHolder, TOTAL_FRAME_TIME_METRIC_NAME,
@@ -92,6 +92,7 @@ impl Game {
                 let path = Path::new(&game.main_script_path);
                 game.lua_env.resources.load_resource::<ScriptResource>(
                     path,
+                    None, // The main script is always loaded with no cause.
                     gl,
                     game.lua_env.lua_handle.clone(),
                     game.lua_env.default_events.resource_loaded_event.clone(),
@@ -159,6 +160,7 @@ impl Game {
         let path = Path::new(&game.main_script_path);
         game.lua_env.resources.load_resource::<ScriptResource>(
             path,
+            None,
             gl,
             game.lua_env.lua_handle.clone(),
             game.lua_env.default_events.resource_loaded_event.clone(),
@@ -253,14 +255,18 @@ impl Game {
         {
             let mut env_state = self.lua_env.env_state.borrow_mut();
             let (width, height) = drawable_screen_size(&window.borrow());
+            // imo this is wrong. Having the drawable size is interesting, but we should not mix it with the actual size.
             env_state.window_width = width;
             env_state.window_height = height;
             env_state.is_window_minimized = window.borrow().is_minimized();
             let aspect_ratio = width as f32 / height as f32;
+
             // This works in the editor, but not the runtime.
             // On the web, this is different, the aspect ratio needs to be squared??
             //self.batch.set_aspect_ratio(aspect_ratio * aspect_ratio);
 
+            // This is wrong: only the size matters, not the drawable size for aspect ratio
+            // Size is the actual size, drawable size is about crisp pixels.
             self.lua_env
                 .batch
                 .borrow_mut()
@@ -272,6 +278,8 @@ impl Game {
 
         {
             // This is incorrect on the web.
+            // note that it is right to set this to the drawable size (this is what the viewport is by definition to have an
+            // opengl coordinate system)
             let gl = &self.gl;
             set_viewport(gl, framebuffer_width, framebuffer_height);
         }
@@ -337,6 +345,9 @@ impl Game {
         };
         self.plugin_env.pre_lua_hook(plugin_interface);
 
+        // We poll every frame
+        self.lua_env.lua_handle.poll_pending_futures();
+
         let start_of_lua_update = std::time::Instant::now();
         if self.was_main_script_executed {
             let update_fn = self
@@ -345,13 +356,20 @@ impl Game {
                 .lua
                 .globals()
                 .get::<vectarine_plugin_sdk::mlua::Function>("Update");
+
             if let Ok(update_fn) = update_fn {
-                let err = update_fn.call::<()>((delta_time.as_secs_f32(),));
-                if let Err(err) = err {
-                    print_lua_error_from_error(&self.lua_env.lua_handle, &err);
-                }
+                let future = update_fn.call_async::<()>((delta_time.as_secs_f32(),));
+                self.lua_env
+                    .lua_handle
+                    .async_handler
+                    .borrow_mut()
+                    .execute_frame(&self.lua_env.lua_handle, future, true);
             } else {
-                print_warn("Update() function not found".to_string());
+                // If there are not futures pending, the update function will never exist.
+                // But if there are futures, we might need to wait for them to create the update function.
+                if !self.lua_env.lua_handle.are_futures_pending() {
+                    print_warn("Update() function not found".to_string());
+                }
             }
         }
         let lua_update_duration = start_of_lua_update.elapsed();
@@ -436,7 +454,8 @@ pub fn drawable_screen_size(_window: &sdl2::video::Window) -> (u32, u32) {
 
 #[cfg(not(target_os = "emscripten"))]
 pub fn screen_size(window: &sdl2::video::Window) -> (u32, u32) {
-    window.size()
+    // This is what defines a pixel. We don't really care about the "drawable size". It is a multiple of a crisp pixel.
+    window.size() // window.drawable_size() ?? bad function name imo.
 }
 
 #[cfg(target_os = "emscripten")]

--- a/runtime/src/game_resource.rs
+++ b/runtime/src/game_resource.rs
@@ -65,11 +65,15 @@ pub struct ResourceHolder {
     status: RefCell<Status>,
 
     name: String,
+    /// The path to the resources after its canonicalization. There is a bijection between paths and resources. This path is relative to the game project folder.
     path: PathBuf,
     /// A list of ids of other resources that this resource needs to work
     dependencies: RefCell<HashSet<ResourceId>>,
     /// A list of ids of other resources that depend on this resource
     dependent: RefCell<HashSet<ResourceId>>,
+
+    /// The path of the resource that caused this resource to be loaded. Is used to resolve relative paths.
+    loading_cause_resource_path: Option<PathBuf>,
 }
 
 impl ResourceHolder {
@@ -99,7 +103,18 @@ impl ResourceHolder {
         };
 
         self.status.replace(Status::Loading);
-        let abs_path = get_absolute_path(&resource_manager.base_path, &self.path);
+
+        let abs_path = match validate_and_canonicalize_resource_path(
+            &self.path,
+            &resource_manager.base_path,
+            self.loading_cause_resource_path.as_deref(),
+        ) {
+            Err(cause) => {
+                self.status.replace(Status::Error(cause));
+                return;
+            }
+            Ok(abs_path) => abs_path,
+        };
 
         // We pass data to the resource into the closure.
         // As this data needs to be kept alive, every piece of state pass inside needs Rc or Arc.
@@ -268,17 +283,23 @@ impl ResourceManager {
     /// Create a new resource from a file and schedule it for loading.
     /// If the resource already exists at that path, do nothing.
     /// Return the id of the resource.
-    pub fn schedule_load_resource<T: Resource + 'static>(&self, path: &Path) -> ResourceId {
-        self.schedule_load_resource_with_builder::<T, _>(path, T::default)
+    pub fn schedule_load_resource<T: Resource + 'static>(
+        &self,
+        path: &Path,
+        loading_cause_path: Option<&Path>,
+    ) -> ResourceId {
+        self.schedule_load_resource_with_builder::<T, _>(path, loading_cause_path, T::default)
     }
 
     /// Create a new resource from a file and schedule it for loading.
     /// If the resource already exists at that path, do nothing.
     /// Return the id of the resource.
     /// The builder function is called to create the unloaded resource instance.
+    /// We try to validate the path is possible. If we cannot, we use the path as-is.
     pub fn schedule_load_resource_with_builder<T: Resource + 'static, F: FnOnce() -> T>(
         &self,
         path: &Path,
+        loading_cause_path: Option<&Path>,
         builder: F,
     ) -> ResourceId {
         if let Some(id) = self.get_id_by_path(path) {
@@ -292,12 +313,15 @@ impl ResourceManager {
             .to_string_lossy()
             .to_string();
 
+        let standard_path = resolve_dot_relative_paths(path, loading_cause_path);
+
         self.resources.borrow_mut().push(Rc::new(ResourceHolder {
             status: RefCell::new(Status::Unloaded),
-            path: path.to_path_buf(),
+            path: standard_path,
             name,
             dependencies: RefCell::new(HashSet::new()),
             dependent: RefCell::new(HashSet::new()),
+            loading_cause_resource_path: loading_cause_path.map(|p| p.to_path_buf()),
             resource,
         }));
 
@@ -307,6 +331,7 @@ impl ResourceManager {
     pub fn schedule_load_script_resource(
         &self,
         path: &Path,
+        loading_cause_path: Option<&Path>,
         target_table: vectarine_plugin_sdk::mlua::Table,
     ) -> (ResourceId, vectarine_plugin_sdk::mlua::Table) {
         if let Some(id) = self.get_id_by_path(path) {
@@ -325,7 +350,7 @@ impl ResourceManager {
             // We return a reference to the exports of the script which is dynamically updated when reloading.
             return (id, exports.clone());
         }
-        let rid = self.schedule_load_resource_with_builder(path, || {
+        let rid = self.schedule_load_resource_with_builder(path, loading_cause_path, || {
             ScriptResource::make_with_target_table(target_table.clone())
         });
         (rid, target_table)
@@ -337,6 +362,7 @@ impl ResourceManager {
     pub fn load_resource<T: Resource + 'static>(
         self: &Rc<Self>,
         path: &Path,
+        loading_cause_path: Option<&Path>,
         gl: Arc<glow::Context>,
         lua: Rc<LuaHandle>,
         loaded_event: EventType,
@@ -344,11 +370,12 @@ impl ResourceManager {
         if let Some(id) = self.get_id_by_path(path) {
             return id;
         }
-        let id = self.schedule_load_resource::<T>(path);
+        let id = self.schedule_load_resource::<T>(path, loading_cause_path);
         self.reload(id, gl, lua, loaded_event);
         id
     }
 
+    /// Declare that the resource with id `resource_id` depends on the resource at `path`.
     fn declare_dependency<T: Resource + 'static>(
         self: &Rc<Self>,
         resource_id: ResourceId,
@@ -370,7 +397,8 @@ impl ResourceManager {
             resource.dependent.borrow_mut().insert(resource_id);
             return;
         };
-        self.schedule_load_resource::<T>(path);
+        let loading_cause_path = Some(resource.path.as_path()); // Self caused the resource at `path` to be loaded.
+        self.schedule_load_resource::<T>(path, loading_cause_path);
     }
 
     pub fn reload(
@@ -525,8 +553,24 @@ pub trait Resource: ResourceToAny {
 }
 
 pub fn get_absolute_path(current_base_path: &Path, resource_path: &Path) -> String {
+    // canonicalize cannot be called here. we are in the runtime, there is potentially no true filesystem!
     let abs_path = current_base_path.join(resource_path);
-    // let abs_path = abs_path.canonicalize().unwrap_or(abs_path);
+
+    // Absolutize by removing . and .. components. We need to make the path unique.
+    let components = abs_path.components().collect::<Vec<_>>();
+    let mut stack = Vec::new();
+    for component in components {
+        match component {
+            std::path::Component::ParentDir => {
+                stack.pop();
+            }
+            std::path::Component::CurDir => {}
+            _ => {
+                stack.push(component);
+            }
+        }
+    }
+    let abs_path = stack.iter().collect::<PathBuf>();
     abs_path.to_string_lossy().replace("\\", "/")
 }
 pub fn get_canonical_absolute_path(current_base_path: &Path, resource_path: &Path) -> PathBuf {
@@ -534,6 +578,54 @@ pub fn get_canonical_absolute_path(current_base_path: &Path, resource_path: &Pat
         .join(resource_path)
         .canonicalize()
         .unwrap_or_else(|_| current_base_path.join(resource_path))
+}
+
+pub fn has_no_uppercase(s: &str) -> bool {
+    s.chars().all(|c| !c.is_ascii_uppercase())
+}
+
+/// If a path is of the form "./filename.extension", it is relative to the file loading the resource. In this
+/// case, we resolve the path provided
+pub fn resolve_dot_relative_paths(
+    maybe_dot_relative_path: &Path,
+    base_path: Option<&Path>,
+) -> PathBuf {
+    let components = maybe_dot_relative_path.components().collect::<Vec<_>>();
+    if components.is_empty() {
+        return maybe_dot_relative_path.to_path_buf();
+    }
+    let first_path = components[0];
+
+    if first_path == std::path::Component::CurDir
+        && let Some(base_path) = base_path
+    {
+        // The path is relative to the loading_cause_path.
+        return PathBuf::from(get_absolute_path(
+            base_path.parent().expect("Loading cause path has a parent"),
+            maybe_dot_relative_path,
+        ));
+    }
+    maybe_dot_relative_path.to_path_buf()
+}
+
+/// Depending on the platform, paths can be interpreted in different ways (case-sensitivity, relative vs absolute, etc.)
+/// To avoid ambiguity, we ban some types of paths and product and error describing why that path is not valid.
+pub fn validate_and_canonicalize_resource_path(
+    resource_path: &Path,
+    game_project_path: &Path,
+    maybe_loading_cause_path: Option<&Path>,
+) -> Result<String, String> {
+    if !has_no_uppercase(&resource_path.to_string_lossy()) {
+        return Err("Resource paths must be lowercase to be cross-platform!".to_string());
+    }
+
+    // All paths must be of the form:
+    // - "foldername/filename.extension" (in that case, the path is given from the root of the game project folder)
+    // - "./filename.extension" (in that case, the path is relative to the file loading the resource)
+
+    let resolved_path = resolve_dot_relative_paths(resource_path, maybe_loading_cause_path);
+    let abs_path = get_absolute_path(game_project_path, resolved_path.as_path());
+    Ok(abs_path)
 }
 
 pub trait ResourceToAny: 'static {

--- a/runtime/src/game_resource.rs
+++ b/runtime/src/game_resource.rs
@@ -6,9 +6,9 @@ use std::{
     sync::Arc,
 };
 
-use vectarine_plugin_sdk::glow;
 use vectarine_plugin_sdk::mlua::IntoLua;
 use vectarine_plugin_sdk::serde::{Deserialize, Serialize};
+use vectarine_plugin_sdk::{egui::ahash::HashMap, glow};
 
 use crate::{
     game_resource::script_resource::ScriptResource,
@@ -147,6 +147,16 @@ impl ResourceHolder {
         );
     }
 
+    /// For resources that are loaded in an async manner, you can use this to mark them as ready if you have access to the resource holder.
+    pub fn mark_as_ready(&self) {
+        self.status.replace(Status::Loaded);
+    }
+
+    /// For resources that are loaded in an async manner, you can use this to mark them as error if you have access to the resource holder.
+    pub fn mark_as_error(&self, error_message: String) {
+        self.status.replace(Status::Error(error_message));
+    }
+
     pub fn get_name(&self) -> &str {
         &self.name
     }
@@ -195,6 +205,8 @@ impl ResourceHolder {
 pub struct ResourceManager {
     file_system: Box<dyn ReadOnlyFileSystem>,
     resources: RefCell<Vec<Rc<ResourceHolder>>>,
+    // Optimization to find resource ids in O(1)
+    path_to_id: RefCell<HashMap<PathBuf, ResourceId>>,
     base_path: PathBuf,
 }
 
@@ -225,6 +237,7 @@ impl std::fmt::Debug for ResourceManager {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct DependencyReporter {
     resource_manager: Weak<ResourceManager>,
 }
@@ -256,6 +269,26 @@ impl DependencyReporter {
             .upgrade()
             .ok_or_else(|| "Failed to upgrade ResourceManager".to_string())?;
         resource_manager.get_by_id::<T>(*resource_id)
+    }
+
+    /// For resources that are loaded in an async manner, you can use this to mark them as ready if you have access to the resource holder.
+    pub fn mark_as_ready(&self, resource_id: ResourceId) {
+        let resource_manager = self
+            .resource_manager
+            .upgrade()
+            .expect("Failed to upgrade ResourceManager");
+        let holder = resource_manager.get_holder_by_id(resource_id);
+        holder.mark_as_ready();
+    }
+
+    /// For resources that are loaded in an async manner, you can use this to mark them as error if you have access to the resource holder.
+    pub fn mark_as_error(&self, resource_id: ResourceId, error_message: String) {
+        let resource_manager = self
+            .resource_manager
+            .upgrade()
+            .expect("Failed to upgrade ResourceManager");
+        let holder = resource_manager.get_holder_by_id(resource_id);
+        holder.mark_as_error(error_message);
     }
 }
 
@@ -305,7 +338,6 @@ impl ResourceManager {
         if let Some(id) = self.get_id_by_path(path) {
             return id;
         }
-        println!("Scheduled loading: {}", path.display());
         let id = self.resources.borrow().len();
         let resource = Rc::new(builder());
         let name = path

--- a/runtime/src/game_resource.rs
+++ b/runtime/src/game_resource.rs
@@ -298,6 +298,7 @@ impl ResourceManager {
             resources: RefCell::new(Vec::new()),
             base_path: base_path.to_path_buf(),
             file_system,
+            path_to_id: RefCell::new(HashMap::default()),
         }
     }
 
@@ -305,11 +306,14 @@ impl ResourceManager {
         &*self.file_system
     }
 
+    /// Used when function seem to want a resource manager, but don't actually need it.
+    /// Contains no resources and cannot load them. All resources will get an error status.
     pub fn dummy_manager() -> Self {
         Self {
             resources: RefCell::new(Vec::new()),
             base_path: PathBuf::new(),
             file_system: Box::new(DummyFileSystem {}),
+            path_to_id: RefCell::new(HashMap::default()),
         }
     }
 
@@ -335,18 +339,20 @@ impl ResourceManager {
         loading_cause_path: Option<&Path>,
         builder: F,
     ) -> ResourceId {
-        if let Some(id) = self.get_id_by_path(path) {
+        let standard_path = resolve_dot_relative_paths(path, loading_cause_path);
+        let canonical_path = get_canonical_absolute_path(&self.base_path, &standard_path);
+
+        if let Some(&id) = self.path_to_id.borrow().get(&canonical_path) {
             return id;
         }
-        let id = self.resources.borrow().len();
+
+        let id = ResourceId(self.resources.borrow().len());
         let resource = Rc::new(builder());
         let name = path
             .file_stem()
             .unwrap_or_default()
             .to_string_lossy()
             .to_string();
-
-        let standard_path = resolve_dot_relative_paths(path, loading_cause_path);
 
         self.resources.borrow_mut().push(Rc::new(ResourceHolder {
             status: RefCell::new(Status::Unloaded),
@@ -358,7 +364,9 @@ impl ResourceManager {
             resource,
         }));
 
-        ResourceId(id)
+        self.path_to_id.borrow_mut().insert(canonical_path, id);
+
+        id
     }
 
     pub fn schedule_load_script_resource(
@@ -452,17 +460,9 @@ impl ResourceManager {
         );
     }
 
-    /// Performance: O(n) for now. Store the ID and use instead get_by_id if you already have the id.
-    /// instead of get_by_path.
     pub fn get_id_by_path(&self, path: &Path) -> Option<ResourceId> {
         let to_match = get_canonical_absolute_path(&self.base_path, path);
-        for (i, res) in self.resources.borrow().iter().enumerate() {
-            let p = get_canonical_absolute_path(&self.base_path, &res.path);
-            if to_match == p {
-                return Some(ResourceId(i));
-            }
-        }
-        None
+        self.path_to_id.borrow().get(&to_match).copied()
     }
 
     pub fn get_by_id<T: Resource + 'static>(&self, id: ResourceId) -> Result<Rc<T>, String> {

--- a/runtime/src/game_resource.rs
+++ b/runtime/src/game_resource.rs
@@ -328,6 +328,32 @@ impl ResourceManager {
         self.schedule_load_resource_with_builder::<T, _>(path, loading_cause_path, T::default)
     }
 
+    /// Most of the time, cyclic imports are ok, except for scripts, because they are loaded in an async way.
+    pub fn is_cyclic_loading_request(
+        &self,
+        canonical_initial_requested_path: &Path,
+        canonical_loading_cause_path: &Path,
+    ) -> bool {
+        if canonical_initial_requested_path == canonical_loading_cause_path {
+            return true;
+        }
+        let maybe_resource = self.get_id_by_path(canonical_loading_cause_path);
+        let Some(resource_id) = maybe_resource else {
+            println!(
+                "This is strange, the loading cause of a resource does not exist: {}",
+                canonical_loading_cause_path.display()
+            );
+            return false;
+        };
+        let maybe_cause = &self
+            .get_holder_by_id(resource_id)
+            .loading_cause_resource_path;
+        let Some(cause) = maybe_cause else {
+            return false; // we reached the root, there were no cycles!
+        };
+        self.is_cyclic_loading_request(canonical_initial_requested_path, cause)
+    }
+
     /// Create a new resource from a file and schedule it for loading.
     /// If the resource already exists at that path, do nothing.
     /// Return the id of the resource.
@@ -335,20 +361,19 @@ impl ResourceManager {
     /// We try to validate the path is possible. If we cannot, we use the path as-is.
     pub fn schedule_load_resource_with_builder<T: Resource + 'static, F: FnOnce() -> T>(
         &self,
-        path: &Path,
+        relative_path: &Path,
         loading_cause_path: Option<&Path>,
         builder: F,
     ) -> ResourceId {
-        let standard_path = resolve_dot_relative_paths(path, loading_cause_path);
-        let canonical_path = get_canonical_absolute_path(&self.base_path, &standard_path);
+        let standard_path = resolve_dot_relative_paths(relative_path, loading_cause_path);
 
-        if let Some(&id) = self.path_to_id.borrow().get(&canonical_path) {
+        if let Some(&id) = self.path_to_id.borrow().get(&standard_path) {
             return id;
         }
 
         let id = ResourceId(self.resources.borrow().len());
         let resource = Rc::new(builder());
-        let name = path
+        let name = relative_path
             .file_stem()
             .unwrap_or_default()
             .to_string_lossy()
@@ -356,7 +381,7 @@ impl ResourceManager {
 
         self.resources.borrow_mut().push(Rc::new(ResourceHolder {
             status: RefCell::new(Status::Unloaded),
-            path: standard_path,
+            path: standard_path.clone(),
             name,
             dependencies: RefCell::new(HashSet::new()),
             dependent: RefCell::new(HashSet::new()),
@@ -364,7 +389,7 @@ impl ResourceManager {
             resource,
         }));
 
-        self.path_to_id.borrow_mut().insert(canonical_path, id);
+        self.path_to_id.borrow_mut().insert(standard_path, id);
 
         id
     }
@@ -461,8 +486,7 @@ impl ResourceManager {
     }
 
     pub fn get_id_by_path(&self, path: &Path) -> Option<ResourceId> {
-        let to_match = get_canonical_absolute_path(&self.base_path, path);
-        self.path_to_id.borrow().get(&to_match).copied()
+        self.path_to_id.borrow().get(path).copied()
     }
 
     pub fn get_by_id<T: Resource + 'static>(&self, id: ResourceId) -> Result<Rc<T>, String> {
@@ -607,10 +631,7 @@ pub fn get_absolute_path(current_base_path: &Path, resource_path: &Path) -> Stri
     abs_path.to_string_lossy().replace("\\", "/")
 }
 pub fn get_canonical_absolute_path(current_base_path: &Path, resource_path: &Path) -> PathBuf {
-    current_base_path
-        .join(resource_path)
-        .canonicalize()
-        .unwrap_or_else(|_| current_base_path.join(resource_path))
+    get_absolute_path(current_base_path, resource_path).into()
 }
 
 pub fn has_no_uppercase(s: &str) -> bool {

--- a/runtime/src/game_resource.rs
+++ b/runtime/src/game_resource.rs
@@ -305,6 +305,7 @@ impl ResourceManager {
         if let Some(id) = self.get_id_by_path(path) {
             return id;
         }
+        println!("Scheduled loading: {}", path.display());
         let id = self.resources.borrow().len();
         let resource = Rc::new(builder());
         let name = path

--- a/runtime/src/game_resource/script_resource.rs
+++ b/runtime/src/game_resource/script_resource.rs
@@ -16,19 +16,36 @@ pub struct ScriptResource {
 impl Resource for ScriptResource {
     fn load_from_data(
         self: std::rc::Rc<Self>,
-        _assigned_id: ResourceId,
-        _dependency_reporter: &super::DependencyReporter,
+        assigned_id: ResourceId,
+        dependency_reporter: &super::DependencyReporter,
         lua: &Rc<LuaHandle>,
         _gl: std::sync::Arc<glow::Context>,
         path: &Path,
         data: Box<[u8]>,
     ) -> Status {
-        // Problem: async_file_file needs to be able to signal, when the future is completed, that the given resource is ready.
-        let finished =
-            lua.async_run_file_and_display_error(&data, path, self.target_table.as_ref());
         self.script.replace(Some(data.to_vec()));
 
-        if finished {
+        let dependency_reporter = dependency_reporter.clone();
+        let lua_future = lua.clone();
+        let path = path.to_path_buf();
+        let future = Box::pin(async move {
+            let result = lua_future
+                .async_run_file_and_display_error(&data, &path, self.target_table.as_ref())
+                .await;
+            match result {
+                Ok(_) => {
+                    dependency_reporter.mark_as_ready(assigned_id);
+                    Ok(())
+                }
+                Err(e) => {
+                    dependency_reporter.mark_as_error(assigned_id, e.to_string());
+                    Err(e)
+                }
+            }
+        });
+
+        let is_ready = lua.async_handler.borrow_mut().schedule_future(lua, future);
+        if is_ready {
             Status::Loaded
         } else {
             Status::Loading

--- a/runtime/src/game_resource/script_resource.rs
+++ b/runtime/src/game_resource/script_resource.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, path::Path, rc::Rc};
 
 use crate::{
     game_resource::{Resource, ResourceId, Status},
-    lua_env::{LuaHandle, run_file_and_display_error_from_lua_handle},
+    lua_env::LuaHandle,
 };
 use vectarine_plugin_sdk::glow;
 
@@ -23,9 +23,16 @@ impl Resource for ScriptResource {
         path: &Path,
         data: Box<[u8]>,
     ) -> Status {
-        run_file_and_display_error_from_lua_handle(lua, &data, path, self.target_table.as_ref());
+        // Problem: async_file_file needs to be able to signal, when the future is completed, that the given resource is ready.
+        let finished =
+            lua.async_run_file_and_display_error(&data, path, self.target_table.as_ref());
         self.script.replace(Some(data.to_vec()));
-        Status::Loaded
+
+        if finished {
+            Status::Loaded
+        } else {
+            Status::Loading
+        }
     }
 
     fn draw_debug_gui(

--- a/runtime/src/io/localfs.rs
+++ b/runtime/src/io/localfs.rs
@@ -20,11 +20,11 @@ impl ReadOnlyFileSystem for LocalFileSystem {
         };
 
         let path = Path::new(filename);
-        if path.is_relative() // Only perform this check for relative paths.
-            && let Ok(canonical) = path.canonicalize()
-        {
+
+        if let Ok(canonical) = path.canonicalize() {
             let canonical_with_slash = canonical.to_string_lossy().replace("\\", "/");
             let ends_with = canonical_with_slash.ends_with(filename);
+
             if !ends_with {
                 // Access might work on MacOS or Windows, but not on the web (path is case-sensitive + you might be accessing a file outside the bundle)
                 // We fail on all platforms for consistency and to catch errors early.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod async_handler;
 pub mod console;
 pub mod game;
 pub mod game_resource;

--- a/runtime/src/lua_env.rs
+++ b/runtime/src/lua_env.rs
@@ -24,8 +24,10 @@ pub mod lua_ui;
 pub mod lua_vec2;
 pub mod lua_vec4;
 
+use crate::async_handler::{AsyncLuaHandle, make_resource_future};
 use crate::console::{print_lua_error, print_warn};
 use crate::game_resource::ResourceManager;
+use crate::game_resource::script_resource::ScriptResource;
 use crate::graphics::batchdraw::BatchDraw2d;
 use crate::io::IoEnvState;
 
@@ -41,6 +43,74 @@ pub const DEPRECATED_MODULES: &[(&str, &str)] = &[];
 pub struct LuaHandle {
     pub lua: vectarine_plugin_sdk::mlua::Lua,
     pub project_path: PathBuf,
+
+    // Contains the futures that need to be polled
+    pub async_handler: Rc<RefCell<AsyncLuaHandle>>,
+}
+
+impl LuaHandle {
+    pub fn poll_pending_futures(self: &Rc<Self>) {
+        self.async_handler.borrow_mut().poll_pending_futures(self);
+    }
+
+    pub fn are_futures_pending(self: &Rc<Self>) -> bool {
+        self.async_handler.borrow().are_futures_pending()
+    }
+
+    /// Run the given Lua file content assuming it is at the given path.
+    /// If the file returns a table, and a target_table is provided, the table will be merged into the target_table.
+    /// Returns true if the execution was synchronous and completed, false if it was asynchronous and is still running.
+    pub fn async_run_file_and_display_error(
+        self: &Rc<Self>,
+        file_content: &[u8],
+        file_path: &Path,
+        target_table: Option<&vectarine_plugin_sdk::mlua::Table>,
+    ) -> bool {
+        // lua.set_compiler(compiler);
+        // Note: We could change the optimization level of the chunk here (for example, inside the runtime)
+        let content_vec = file_content.to_vec();
+        let file_path_str = file_path.to_string_lossy().into_owned();
+        let file_path_name = format!("@{}", file_path_str);
+        let target_table_owned = target_table.cloned();
+
+        // Note: We could change the optimization level of the chunk here (for example, inside the runtime)
+        let lua_chunk = self.lua.load(content_vec);
+        let future = Box::pin(async move {
+            let result = lua_chunk
+                .set_name(file_path_name)
+                .eval_async::<vectarine_plugin_sdk::mlua::Value>()
+                .await;
+
+            match result {
+                Err(error) => Err(error),
+                Ok(value) => {
+                    // Merge the table with the argument table if provided.
+                    let Some(target_table) = target_table_owned else {
+                        return Ok(());
+                    };
+                    let table = value.as_table();
+                    let Some(table) = table else {
+                        print_warn(format!(
+                            "Script {} did not return a table, so we cannot put its exports into the table provided when calling LoadScript.",
+                            file_path_str
+                        ));
+                        return Ok(());
+                    };
+
+                    for pair in table
+                    .pairs::<vectarine_plugin_sdk::mlua::Value, vectarine_plugin_sdk::mlua::Value>()
+                {
+                    let Ok((key, value)) = pair else { continue };
+                    let _ = target_table.raw_set(key, value);
+                }
+                    Ok(())
+                }
+            }
+        });
+        self.async_handler
+            .borrow_mut()
+            .schedule_future(&self, future)
+    }
 }
 
 pub struct LuaEnvironment {
@@ -86,9 +156,11 @@ impl LuaEnvironment {
                 .set_type_info_level(1),
         );
         let _ = lua.sandbox(false);
+        let async_handler = Rc::new(RefCell::new(AsyncLuaHandle::new()));
         let lua_handle = Rc::new(LuaHandle {
             lua,
             project_path: resources.get_resource_path(),
+            async_handler: async_handler.clone(),
         });
 
         // We create a table used to store rust state that is tied to the lua environment, for internal use.
@@ -177,33 +249,67 @@ impl LuaEnvironment {
             .globals()
             .get::<vectarine_plugin_sdk::mlua::Function>("require")
             .unwrap();
-        add_global_fn(
-            &lua_handle.lua,
-            "require",
+        add_global_async_fn(&lua_handle.lua, "require", {
+            let resources = resources.clone();
             move |lua, module_name: String| {
                 // We provide a custom require with the following features:
                 // - Can require @vectarine/* modules (like @vectarine/vec)
                 // - Can require files in the script folder by their names.
-                if module_name.starts_with("@vectarine/") {
-                    for (deprecated_module, message) in DEPRECATED_MODULES {
-                        if module_name == format!("@vectarine/{}", deprecated_module) {
-                            print_warn(message.to_string());
+                let original_require = original_require.clone();
+                let resources = resources.clone();
+                let module_path = lua_loader::get_path_of_current_chunk(&lua);
+                async move {
+                    if module_name.starts_with("@vectarine/") {
+                        for (deprecated_module, message) in DEPRECATED_MODULES {
+                            if module_name == format!("@vectarine/{}", deprecated_module) {
+                                print_warn(message.to_string());
+                            }
                         }
+                        return original_require.call(module_name);
                     }
 
-                    return original_require.call(module_name);
+                    let path = PathBuf::from(module_name.clone() + ".luau");
+
+                    println!(
+                        "Async loading of: {} using cause: {:?}",
+                        path.display(),
+                        module_path.as_deref()
+                    );
+                    let maybe_script_resource = make_resource_future::<ScriptResource>(
+                        resources,
+                        module_path.as_deref(),
+                        lua.create_table()?,
+                        path,
+                    )
+                    .await;
+
+                    println!(
+                        "A script resource finished loading: {:?}",
+                        maybe_script_resource.is_some()
+                    );
+
+                    let make_empty_table = || {
+                        let module = lua.create_table()?;
+                        module.raw_set("@vectarine/filename", module_name)?;
+                        module.raw_set(
+                            "info",
+                            "Thank you cowboy! But your module is in another castle!",
+                        )?;
+                        Ok(module)
+                    };
+                    if let Some(script_table) =
+                        maybe_script_resource.and_then(|sr| sr.target_table.clone())
+                    {
+                        Ok(script_table)
+                    } else {
+                        println!(
+                            "The export table of that resource was empty, returning an empty table instead."
+                        );
+                        make_empty_table() // should not happen
+                    }
                 }
-                let module = lua.create_table()?;
-                module.raw_set("@vectarine/filename", module_name)?;
-                module.raw_set(
-                    "info",
-                    "Thank you cowboy! But your module is in another castle!",
-                )?;
-                // We return an empty table as this is just for the types.
-                // We put a message to indicate that. loadScript is what loads the script, not require.
-                Ok(module)
-            },
-        );
+            }
+        });
 
         // Add this to Debug module?
         add_global_fn(
@@ -226,7 +332,8 @@ impl LuaEnvironment {
     }
 
     pub fn run_file_and_display_error(&self, file_content: &[u8], file_path: &Path) {
-        run_file_and_display_error_from_lua_handle(&self.lua_handle, file_content, file_path, None);
+        self.lua_handle
+            .async_run_file_and_display_error(file_content, file_path, None);
     }
 }
 
@@ -243,6 +350,23 @@ where
 }
 
 #[allow(clippy::unwrap_used)]
+pub fn add_global_async_fn<F, A, FR, R>(lua: &vectarine_plugin_sdk::mlua::Lua, name: &str, func: F)
+where
+    FR: Future<Output = vectarine_plugin_sdk::mlua::Result<R>>
+        + vectarine_plugin_sdk::mlua::MaybeSend
+        + 'static,
+    R: vectarine_plugin_sdk::mlua::IntoLuaMulti,
+    F: Fn(vectarine_plugin_sdk::mlua::Lua, A) -> FR
+        + vectarine_plugin_sdk::mlua::MaybeSend
+        + 'static,
+    A: vectarine_plugin_sdk::mlua::FromLuaMulti,
+{
+    lua.globals()
+        .set(name, lua.create_async_function(func).unwrap())
+        .unwrap()
+}
+
+#[allow(clippy::unwrap_used)]
 pub fn add_fn_to_table<F, A, R>(
     lua: &vectarine_plugin_sdk::mlua::Lua,
     table: &vectarine_plugin_sdk::mlua::Table,
@@ -254,49 +378,6 @@ pub fn add_fn_to_table<F, A, R>(
     R: vectarine_plugin_sdk::mlua::IntoLuaMulti,
 {
     table.set(name, lua.create_function(func).unwrap()).unwrap();
-}
-
-/// Run the given Lua file content assuming it is at the given path.
-/// If the file returns a table, and a target_table is provided, the table will be merged into the target_table.
-pub fn run_file_and_display_error_from_lua_handle(
-    lua_handle: &LuaHandle,
-    file_content: &[u8],
-    file_path: &Path,
-    target_table: Option<&vectarine_plugin_sdk::mlua::Table>,
-) {
-    // lua.set_compiler(compiler);
-    let lua_chunk = lua_handle.lua.load(file_content);
-    // Note: We could change the optimization level of the chunk here (for example, inside the runtime)
-    let result = lua_chunk
-        .set_name(format!("@{}", file_path.to_string_lossy()))
-        .eval::<vectarine_plugin_sdk::mlua::Value>();
-
-    match result {
-        Err(error) => {
-            print_lua_error_from_error(lua_handle, &error);
-        }
-        Ok(value) => {
-            // Merge the table with the argument table if provided.
-            let Some(target_table) = target_table else {
-                return;
-            };
-            let table = value.as_table();
-            let Some(table) = table else {
-                print_warn(format!(
-                    "Script {} did not return a table, so we cannot put its exports into the table provided when calling LoadScript.",
-                    file_path.to_string_lossy()
-                ));
-                return;
-            };
-
-            for pair in table
-                .pairs::<vectarine_plugin_sdk::mlua::Value, vectarine_plugin_sdk::mlua::Value>()
-            {
-                let Ok((key, value)) = pair else { continue };
-                let _ = target_table.raw_set(key, value);
-            }
-        }
-    }
 }
 
 pub fn register_vectarine_module(

--- a/runtime/src/lua_env.rs
+++ b/runtime/src/lua_env.rs
@@ -60,21 +60,21 @@ impl LuaHandle {
     /// Run the given Lua file content assuming it is at the given path.
     /// If the file returns a table, and a target_table is provided, the table will be merged into the target_table.
     /// Returns true if the execution was synchronous and completed, false if it was asynchronous and is still running.
-    pub fn async_run_file_and_display_error(
+    pub fn schedule_run_file_and_display_error(
         self: &Rc<Self>,
         file_content: &[u8],
         file_path: &Path,
         target_table: Option<&vectarine_plugin_sdk::mlua::Table>,
     ) -> bool {
-        // lua.set_compiler(compiler);
-        // Note: We could change the optimization level of the chunk here (for example, inside the runtime)
         let content_vec = file_content.to_vec();
         let file_path_str = file_path.to_string_lossy().into_owned();
         let file_path_name = format!("@{}", file_path_str);
         let target_table_owned = target_table.cloned();
 
         // Note: We could change the optimization level of the chunk here (for example, inside the runtime)
+        // lua_chunk.set_compiler(compiler);
         let lua_chunk = self.lua.load(content_vec);
+
         let future = Box::pin(async move {
             let result = lua_chunk
                 .set_name(file_path_name)
@@ -91,7 +91,7 @@ impl LuaHandle {
                     let table = value.as_table();
                     let Some(table) = table else {
                         print_warn(format!(
-                            "Script {} did not return a table, so we cannot put its exports into the table provided when calling LoadScript.",
+                            "Script {} did not return a table, so we cannot put its exports into the table provided when calling require.",
                             file_path_str
                         ));
                         return Ok(());
@@ -109,7 +109,54 @@ impl LuaHandle {
         });
         self.async_handler
             .borrow_mut()
-            .schedule_future(&self, future)
+            .schedule_future(self, future)
+    }
+
+    pub async fn async_run_file_and_display_error(
+        self: &Rc<Self>,
+        file_content: &[u8],
+        file_path: &Path,
+        target_table: Option<&vectarine_plugin_sdk::mlua::Table>,
+    ) -> Result<(), vectarine_plugin_sdk::mlua::Error> {
+        let content_vec = file_content.to_vec();
+        let file_path_str = file_path.to_string_lossy().into_owned();
+        let file_path_name = format!("@{}", file_path_str);
+        let target_table_owned = target_table.cloned();
+
+        // Note: We could change the optimization level of the chunk here (for example, inside the runtime)
+        // lua_chunk.set_compiler(compiler);
+        let lua_chunk = self.lua.load(content_vec);
+
+        let result = lua_chunk
+            .set_name(file_path_name)
+            .eval_async::<vectarine_plugin_sdk::mlua::Value>()
+            .await;
+
+        match result {
+            Err(error) => Err(error),
+            Ok(value) => {
+                // Merge the table with the argument table if provided.
+                let Some(target_table) = target_table_owned else {
+                    return Ok(());
+                };
+                let table = value.as_table();
+                let Some(table) = table else {
+                    print_warn(format!(
+                        "Script {} did not return a table, so we cannot put its exports into the table provided when calling require.",
+                        file_path_str
+                    ));
+                    return Ok(());
+                };
+
+                for pair in table
+                    .pairs::<vectarine_plugin_sdk::mlua::Value, vectarine_plugin_sdk::mlua::Value>()
+                {
+                    let Ok((key, value)) = pair else { continue };
+                    let _ = target_table.raw_set(key, value);
+                }
+                Ok(())
+            }
+        }
     }
 }
 
@@ -270,11 +317,6 @@ impl LuaEnvironment {
 
                     let path = PathBuf::from(module_name.clone() + ".luau");
 
-                    println!(
-                        "Async loading of: {} using cause: {:?}",
-                        path.display(),
-                        module_path.as_deref()
-                    );
                     let maybe_script_resource = make_resource_future::<ScriptResource>(
                         resources,
                         module_path.as_deref(),
@@ -282,11 +324,6 @@ impl LuaEnvironment {
                         path,
                     )
                     .await;
-
-                    println!(
-                        "A script resource finished loading: {:?}",
-                        maybe_script_resource.is_some()
-                    );
 
                     let make_empty_table = || {
                         let module = lua.create_table()?;
@@ -302,9 +339,6 @@ impl LuaEnvironment {
                     {
                         Ok(script_table)
                     } else {
-                        println!(
-                            "The export table of that resource was empty, returning an empty table instead."
-                        );
                         make_empty_table() // should not happen
                     }
                 }
@@ -333,7 +367,7 @@ impl LuaEnvironment {
 
     pub fn run_file_and_display_error(&self, file_content: &[u8], file_path: &Path) {
         self.lua_handle
-            .async_run_file_and_display_error(file_content, file_path, None);
+            .schedule_run_file_and_display_error(file_content, file_path, None);
     }
 }
 

--- a/runtime/src/lua_env.rs
+++ b/runtime/src/lua_env.rs
@@ -207,7 +207,7 @@ impl LuaEnvironment {
         let lua_handle = Rc::new(LuaHandle {
             lua,
             project_path: resources.get_resource_path(),
-            async_handler: async_handler.clone(),
+            async_handler,
         });
 
         // We create a table used to store rust state that is tied to the lua environment, for internal use.

--- a/runtime/src/lua_env.rs
+++ b/runtime/src/lua_env.rs
@@ -296,6 +296,7 @@ impl LuaEnvironment {
             .globals()
             .get::<vectarine_plugin_sdk::mlua::Function>("require")
             .unwrap();
+
         add_global_async_fn(&lua_handle.lua, "require", {
             let resources = resources.clone();
             move |lua, module_name: String| {
@@ -317,6 +318,20 @@ impl LuaEnvironment {
 
                     let path = PathBuf::from(module_name.clone() + ".luau");
 
+                    let canonical = crate::game_resource::resolve_dot_relative_paths(
+                        &path,
+                        module_path.as_deref(),
+                    );
+                    if let Some(module_path) = module_path.clone()
+                        && resources.is_cyclic_loading_request(&canonical, &module_path)
+                    {
+                        return Err(vectarine_plugin_sdk::mlua::Error::RuntimeError(format!(
+                            "Cyclic import detected, when requiring {} from {}",
+                            canonical.display(),
+                            module_path.display()
+                        )));
+                    }
+
                     let maybe_script_resource = make_resource_future::<ScriptResource>(
                         resources,
                         module_path.as_deref(),
@@ -325,21 +340,23 @@ impl LuaEnvironment {
                     )
                     .await;
 
-                    let make_empty_table = || {
-                        let module = lua.create_table()?;
-                        module.raw_set("@vectarine/filename", module_name)?;
-                        module.raw_set(
-                            "info",
-                            "Thank you cowboy! But your module is in another castle!",
-                        )?;
-                        Ok(module)
-                    };
                     if let Some(script_table) =
                         maybe_script_resource.and_then(|sr| sr.target_table.clone())
                     {
                         Ok(script_table)
                     } else {
-                        make_empty_table() // should not happen
+                        let make_empty_table = || {
+                            let module = lua.create_table()?;
+                            module.raw_set("@vectarine/filename", module_name)?;
+                            module.raw_set(
+                                "info",
+                                "Thank you cowboy! But your module is in another castle!",
+                            )?;
+                            Ok(module)
+                        };
+                        // Should not happen, this means a script resource was initialized without a target table.
+                        // This is a runtime bug.
+                        make_empty_table()
                     }
                 }
             }

--- a/runtime/src/lua_env/lua_loader.rs
+++ b/runtime/src/lua_env/lua_loader.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 use std::{cell::RefCell, path::Path, rc::Rc};
 
+use vectarine_plugin_sdk::mlua::UserDataMethods;
 use vectarine_plugin_sdk::mlua::{FromLua, IntoLua};
-use vectarine_plugin_sdk::mlua::{UserDataMethods, chunk};
 
 use crate::game_resource::script_resource::ScriptResource;
 use crate::game_resource::tile_resource::TilemapResource;

--- a/runtime/src/lua_env/lua_loader.rs
+++ b/runtime/src/lua_env/lua_loader.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::{cell::RefCell, path::Path, rc::Rc};
 
 use vectarine_plugin_sdk::mlua::UserDataMethods;
@@ -62,17 +63,21 @@ pub fn setup_loader_api(
 
     add_fn_to_table(lua, &loader_module, "loadText", {
         let resources = resources.clone();
-        move |_, path: String| {
-            let id = resources.schedule_load_resource::<TextResource>(Path::new(&path));
+        move |lua, path: String| {
+            let cause = get_path_of_current_chunk(lua);
+            let id = resources
+                .schedule_load_resource::<TextResource>(Path::new(&path), cause.as_deref());
             Ok(TextResourceId::from_id(id))
         }
     });
 
     add_fn_to_table(lua, &loader_module, "loadImage", {
         let resources = resources.clone();
-        move |_, (path, antialiasing): (String, Option<bool>)| {
+        move |lua, (path, antialiasing): (String, Option<bool>)| {
+            let cause = get_path_of_current_chunk(lua);
             let id = resources.schedule_load_resource_with_builder::<ImageResource, _>(
                 Path::new(&path),
+                cause.as_deref(),
                 || ImageResource {
                     texture: RefCell::new(None),
                     egui_id: RefCell::new(None),
@@ -91,40 +96,50 @@ pub fn setup_loader_api(
 
     add_fn_to_table(lua, &loader_module, "loadFont", {
         let resources = resources.clone();
-        move |_, path: String| {
-            let id = resources.schedule_load_resource::<FontResource>(Path::new(&path));
+        move |lua, path: String| {
+            let cause = get_path_of_current_chunk(lua);
+            let id = resources
+                .schedule_load_resource::<FontResource>(Path::new(&path), cause.as_deref());
             Ok(FontResourceId::from_id(id))
         }
     });
 
     add_fn_to_table(lua, &loader_module, "loadAudio", {
         let resources = resources.clone();
-        move |_, path: String| {
-            let id = resources.schedule_load_resource::<AudioResource>(Path::new(&path));
+        move |lua, path: String| {
+            let cause = get_path_of_current_chunk(lua);
+            let id = resources
+                .schedule_load_resource::<AudioResource>(Path::new(&path), cause.as_deref());
             Ok(AudioResourceId::from_id(id))
         }
     });
 
     add_fn_to_table(lua, &loader_module, "loadShader", {
         let resources = resources.clone();
-        move |_, path: String| {
-            let id = resources.schedule_load_resource::<ShaderResource>(Path::new(&path));
+        move |lua, path: String| {
+            let cause = get_path_of_current_chunk(lua);
+            let id = resources
+                .schedule_load_resource::<ShaderResource>(Path::new(&path), cause.as_deref());
             Ok(ShaderResourceId::from_id(id))
         }
     });
 
     add_fn_to_table(lua, &loader_module, "loadTileset", {
         let resources = resources.clone();
-        move |_, path: String| {
-            let id = resources.schedule_load_resource::<TilesetResource>(Path::new(&path));
+        move |lua, path: String| {
+            let cause = get_path_of_current_chunk(lua);
+            let id = resources
+                .schedule_load_resource::<TilesetResource>(Path::new(&path), cause.as_deref());
             Ok(TilesetResourceId::from_id(id))
         }
     });
 
     add_fn_to_table(lua, &loader_module, "loadTilemap", {
         let resources = resources.clone();
-        move |_, path: String| {
-            let id = resources.schedule_load_resource::<TilemapResource>(Path::new(&path));
+        move |lua, path: String| {
+            let cause = get_path_of_current_chunk(lua);
+            let id = resources
+                .schedule_load_resource::<TilemapResource>(Path::new(&path), cause.as_deref());
             Ok(TilemapResourceId::from_id(id))
         }
     });
@@ -132,9 +147,13 @@ pub fn setup_loader_api(
     add_fn_to_table(lua, &loader_module, "loadScript", {
         let resources = resources.clone();
         move |lua, (path, _type_hint): (String, Option<vectarine_plugin_sdk::mlua::Table>)| {
+            let cause = get_path_of_current_chunk(lua);
             let dummy_table = lua.create_table()?;
-            let (id, table) =
-                resources.schedule_load_script_resource(Path::new(&path), dummy_table);
+            let (id, table) = resources.schedule_load_script_resource(
+                Path::new(&path),
+                cause.as_deref(),
+                dummy_table,
+            );
 
             Ok((
                 ScriptResourceId::from_id(id),
@@ -150,20 +169,11 @@ pub fn setup_loader_api(
         move |lua, (): ()| {
             // Level 0 is the rust code, level 1 is the caller.
             // The chunk name has the format @scripts/file.luau in general
-            let maybe_chunk_name = lua
-                .inspect_stack(1, |dbg| {
-                    let source = dbg.source().source;
-                    source.map(|s| s.to_string())
-                })
-                .flatten();
-            let Some(chunk_name) = maybe_chunk_name else {
+            let maybe_path = get_path_of_current_chunk(lua);
+            let Some(path) = maybe_path else {
                 return lua.create_table();
             };
-            let Some(path_name) = chunk_name.strip_prefix("@") else {
-                return lua.create_table();
-            };
-            let path = Path::new(path_name);
-            let resource_id = resources.get_id_by_path(path);
+            let resource_id = resources.get_id_by_path(&path);
             let Some(resource_id) = resource_id else {
                 return lua.create_table();
             };
@@ -182,4 +192,18 @@ pub fn setup_loader_api(
     });
 
     Ok(loader_module)
+}
+
+/// Get the resource path corresponding to the script resource currently being executed.
+fn get_path_of_current_chunk(lua: &vectarine_plugin_sdk::mlua::Lua) -> Option<PathBuf> {
+    let maybe_chunk_name = lua
+        .inspect_stack(1, |dbg| {
+            let source = dbg.source().source;
+            source.map(|s| s.to_string())
+        })
+        .flatten();
+    let chunk_name = maybe_chunk_name?;
+    let path_name = chunk_name.strip_prefix("@")?;
+    let path = PathBuf::from(path_name);
+    Some(path)
 }

--- a/runtime/src/lua_env/lua_loader.rs
+++ b/runtime/src/lua_env/lua_loader.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 use std::{cell::RefCell, path::Path, rc::Rc};
 
-use vectarine_plugin_sdk::mlua::UserDataMethods;
 use vectarine_plugin_sdk::mlua::{FromLua, IntoLua};
+use vectarine_plugin_sdk::mlua::{UserDataMethods, chunk};
 
 use crate::game_resource::script_resource::ScriptResource;
 use crate::game_resource::tile_resource::TilemapResource;
@@ -195,15 +195,18 @@ pub fn setup_loader_api(
 }
 
 /// Get the resource path corresponding to the script resource currently being executed.
-fn get_path_of_current_chunk(lua: &vectarine_plugin_sdk::mlua::Lua) -> Option<PathBuf> {
-    let maybe_chunk_name = lua
-        .inspect_stack(1, |dbg| {
-            let source = dbg.source().source;
-            source.map(|s| s.to_string())
-        })
-        .flatten();
-    let chunk_name = maybe_chunk_name?;
-    let path_name = chunk_name.strip_prefix("@")?;
-    let path = PathBuf::from(path_name);
-    Some(path)
+pub fn get_path_of_current_chunk(lua: &vectarine_plugin_sdk::mlua::Lua) -> Option<PathBuf> {
+    let stack_depths_tried = [1, 2]; // 1 for regular, 2 for async
+    stack_depths_tried.iter().find_map(|depth| {
+        let maybe_chunk_name = lua
+            .inspect_stack(*depth, |dbg| {
+                let source = dbg.source().source;
+                source.map(|s| s.to_string())
+            })
+            .flatten();
+        let chunk_name = maybe_chunk_name?;
+        let path_name = chunk_name.strip_prefix("@")?;
+        let path = PathBuf::from(path_name);
+        Some(path)
+    })
 }

--- a/vectarine-plugin-sdk/Cargo.toml
+++ b/vectarine-plugin-sdk/Cargo.toml
@@ -20,19 +20,19 @@ serde = { version = "1.0.221", features = ["derive"] }
 sdl2 = { version = "0.38", default-features = false, features = ["static-link", "use-vcpkg"] }
 # Jun 1, 2026 commit, needed for Rust 1.94 compatibility, >0.11.6
 # Targets Luau 0.714
-mlua = { git = "https://github.com/mlua-rs/mlua", version = "0.12.0", features = ["luau-jit", "serde", "vendored"] }
+mlua = { git = "https://github.com/mlua-rs/mlua", version = "0.12.0", features = ["luau-jit", "serde", "vendored", "async"] }
 
 [target.'cfg(any(target_os = "macos"))'.dependencies]
 sdl2 = { version = "0.38", default-features = false, features = ["static-link", "use-vcpkg"] }
-mlua = { git = "https://github.com/mlua-rs/mlua", version = "0.12.0", features = ["luau-jit", "serde", "vendored"] }
+mlua = { git = "https://github.com/mlua-rs/mlua", version = "0.12.0", features = ["luau-jit", "serde", "vendored", "async"] }
 
 [target.'cfg(any(target_os = "linux"))'.dependencies]
 sdl2 = { version = "0.38", default-features = false, features = ["static-link", "bundled"] }
-mlua = { git = "https://github.com/mlua-rs/mlua", version = "0.12.0", features = ["luau-jit", "serde", "vendored"] }
+mlua = { git = "https://github.com/mlua-rs/mlua", version = "0.12.0", features = ["luau-jit", "serde", "vendored", "async"] }
 
 [target.'cfg(target_os = "emscripten")'.dependencies]
 sdl2 = { version = "0.38", default-features = false, features = [] }
-mlua = { git = "https://github.com/mlua-rs/mlua", version = "0.12.0", features = ["luau", "serde", "vendored"] }
+mlua = { git = "https://github.com/mlua-rs/mlua", version = "0.12.0", features = ["luau", "serde", "vendored", "async"] }
 
 [package.metadata.vcpkg]
 dependencies = ["sdl2"]


### PR DESCRIPTION
- [x] Added an async runtime to vectarine.
- [x] Deny uppercase in paths to help find these errors earlier
- [x] Clear the screen manually every frame 
- [x] Proper Loading/Loaded set for scripts
- [x] Cyclic module detection

TODO:
- [ ] Custom loading screen when update is not defined but there are pending futures

