### PR TITLE
:bug: Fix issues with path on windows

### DIFF
--- a/editor/src/editorinterface.rs
+++ b/editor/src/editorinterface.rs
@@ -19,6 +19,7 @@ use runtime::{
     egui, egui_glow, glow,
     graphics::batchdraw::BatchDraw2d,
     io::{
+        self,
         fs::{FileSystem, ReadOnlyFileSystem},
         localfs::LocalFileSystem,
     },
@@ -89,9 +90,7 @@ impl EditorState {
         }
 
         LocalFileSystem.write_file(
-            config_path
-                .to_str()
-                .expect("The editor path is valid unicode"), // otherwise, your installation / OS is very cursed
+            &io::localfs::normalize_path(&config_path),
             data.as_bytes(),
             Box::new(|_| {}),
         );
@@ -108,9 +107,7 @@ impl EditorState {
         let trusted_plugins = self.get_trusted_plugins();
 
         LocalFileSystem.read_file(
-            geteditorpaths::get_editor_config_path()
-                .to_str()
-                .expect("The editor path is valid unicode"),
+            &io::localfs::normalize_path(&geteditorpaths::get_editor_config_path()),
             Box::new(move |data: Option<Vec<u8>>| {
                 let Some(data) = data else {
                     return; // no config file
@@ -198,7 +195,7 @@ impl EditorState {
 
     fn update_recent_projects(&self, new_recent_project: &Path) {
         let mut config = self.config.borrow_mut();
-        let project_path_str = new_recent_project.to_string_lossy().to_string();
+        let project_path_str = io::localfs::normalize_path(new_recent_project);
 
         config
             .recent_project_paths
@@ -234,9 +231,9 @@ impl EditorState {
                         return;
                     }
                 };
-                // Bad code here: canonicalization issue.
+
                 self.config.borrow_mut().opened_project_path =
-                    Some(project_path.to_string_lossy().to_string());
+                    Some(io::localfs::normalize_path(project_path));
                 if let Some(project_folder) = project_path.parent() {
                     self.update_recent_projects(project_folder);
                 }

--- a/editor/src/editorinterface.rs
+++ b/editor/src/editorinterface.rs
@@ -234,6 +234,7 @@ impl EditorState {
                         return;
                     }
                 };
+                // Bad code here: canonicalization issue.
                 self.config.borrow_mut().opened_project_path =
                     Some(project_path.to_string_lossy().to_string());
                 if let Some(project_folder) = project_path.parent() {

--- a/editor/src/editorinterface/editorpreferences.rs
+++ b/editor/src/editorinterface/editorpreferences.rs
@@ -73,7 +73,11 @@ pub fn draw_editor_preferences(editor: &mut EditorState, ui: &mut egui::Ui) {
                     let current_editor = config.text_editor;
 
                     egui::ComboBox::new("editor_selector", "")
-                        .selected_text(format!("{}", current_editor.unwrap_or_default()))
+                        .selected_text(
+                            current_editor
+                                .map(|e| format!("{}", e))
+                                .unwrap_or("None".to_string()),
+                        )
                         .show_ui(ui, |ui| {
                             let editors = [
                                 TextEditor::VSCode,

--- a/editor/src/editorinterface/extra/openfileatline.rs
+++ b/editor/src/editorinterface/extra/openfileatline.rs
@@ -15,9 +15,9 @@ pub fn open_file_at_line(file: &Path, line: usize, prefered_text_editor: Option<
     let opened_successfully = match prefered_text_editor {
         None => false,
         Some(TextEditor::Antigravity) => {
-            let is_antigravity = which::which("antigravity").is_ok();
-            if is_antigravity {
-                let res = Command::new("antigravity")
+            let path = which::which("antigravity");
+            if let Ok(antigravity_path) = path {
+                let res = Command::new(antigravity_path)
                     .args(["--goto", format!("{}:{}", absolute_path, line).as_str()])
                     .spawn();
                 res.is_ok()
@@ -26,9 +26,9 @@ pub fn open_file_at_line(file: &Path, line: usize, prefered_text_editor: Option<
             }
         }
         Some(TextEditor::SublimeText) => {
-            let is_sublime = which::which("subl").is_ok();
-            if is_sublime {
-                let res = Command::new("subl")
+            let path = which::which("subl");
+            if let Ok(subl_path) = path {
+                let res = Command::new(subl_path)
                     .args([format!("{}:{}", absolute_path, line).as_str()])
                     .spawn();
                 res.is_ok()
@@ -37,9 +37,9 @@ pub fn open_file_at_line(file: &Path, line: usize, prefered_text_editor: Option<
             }
         }
         Some(TextEditor::Zed) => {
-            let is_zed = which::which("zed").is_ok();
-            if is_zed {
-                let res = Command::new("zed")
+            let path = which::which("zed");
+            if let Ok(zed_path) = path {
+                let res = Command::new(zed_path)
                     .args([format!("{}:{}", absolute_path, line).as_str()])
                     .spawn();
                 res.is_ok()
@@ -48,10 +48,10 @@ pub fn open_file_at_line(file: &Path, line: usize, prefered_text_editor: Option<
             }
         }
         Some(TextEditor::VSCode) => {
-            let is_code = which::which("code").is_ok();
-            if is_code {
+            let path = which::which("code");
+            if let Ok(code_path) = path {
                 // code --goto "path/to/file:line"
-                let res = Command::new("code")
+                let res = Command::new(code_path)
                     .args(["--goto", format!("{}:{}", absolute_path, line).as_str()])
                     .spawn();
                 res.is_ok()
@@ -60,9 +60,9 @@ pub fn open_file_at_line(file: &Path, line: usize, prefered_text_editor: Option<
             }
         }
         Some(TextEditor::Cursor) => {
-            let is_cursor = which::which("cursor").is_ok();
-            if is_cursor {
-                let res = Command::new("cursor")
+            let path = which::which("cursor");
+            if let Ok(cursor_path) = path {
+                let res = Command::new(cursor_path)
                     .args(["--goto", format!("{}:{}", absolute_path, line).as_str()])
                     .spawn();
                 res.is_ok()
@@ -87,9 +87,9 @@ pub fn open_file_at_line(file: &Path, line: usize, prefered_text_editor: Option<
             }
         }
         Some(TextEditor::Emacs) => {
-            let is_emacs = which::which("emacsclient").is_ok();
-            if is_emacs {
-                let res = Command::new("emacsclient")
+            let path = which::which("emacsclient");
+            if let Ok(emacsclient_path) = path {
+                let res = Command::new(emacsclient_path)
                     .args([format!("+{}", line), absolute_path])
                     .spawn();
                 res.is_ok()
@@ -114,9 +114,9 @@ pub fn open_folder(folder_path: &Path, prefered_text_editor: Option<TextEditor>)
     match prefered_text_editor {
         None => false,
         Some(TextEditor::Antigravity) => {
-            let is_antigravity = which::which("antigravity").is_ok();
-            if is_antigravity {
-                let res = Command::new("antigravity")
+            let path = which::which("antigravity");
+            if let Ok(antigravity_path) = path {
+                let res = Command::new(antigravity_path)
                     .args([absolute_path.as_str()])
                     .spawn();
                 res.is_ok()
@@ -125,18 +125,22 @@ pub fn open_folder(folder_path: &Path, prefered_text_editor: Option<TextEditor>)
             }
         }
         Some(TextEditor::SublimeText) => {
-            let is_sublime = which::which("subl").is_ok();
-            if is_sublime {
-                let res = Command::new("subl").args([absolute_path.as_str()]).spawn();
+            let path = which::which("subl");
+            if let Ok(subl_path) = path {
+                let res = Command::new(subl_path)
+                    .args([absolute_path.as_str()])
+                    .spawn();
                 res.is_ok()
             } else {
                 false
             }
         }
         Some(TextEditor::Zed) => {
-            let is_zed = which::which("zed").is_ok();
-            if is_zed {
-                let res = Command::new("zed").args([absolute_path.as_str()]).spawn();
+            let path = which::which("zed");
+            if let Ok(zed_path) = path {
+                let res = Command::new(zed_path)
+                    .args([absolute_path.as_str()])
+                    .spawn();
                 res.is_ok()
             } else {
                 false
@@ -144,21 +148,19 @@ pub fn open_folder(folder_path: &Path, prefered_text_editor: Option<TextEditor>)
         }
         Some(TextEditor::VSCode) => {
             let path = which::which("code");
-            println!("path: {:?}", path);
             if let Ok(code_path) = path {
                 let res = Command::new(code_path)
                     .args([absolute_path.as_str()])
                     .spawn();
-                println!("res: {:?}", res);
                 res.is_ok()
             } else {
                 false
             }
         }
         Some(TextEditor::Cursor) => {
-            let is_cursor = which::which("cursor").is_ok();
-            if is_cursor {
-                let res = Command::new("cursor")
+            let path = which::which("cursor");
+            if let Ok(cursor_path) = path {
+                let res = Command::new(cursor_path)
                     .args([absolute_path.as_str()])
                     .spawn();
                 res.is_ok()
@@ -183,9 +185,9 @@ pub fn open_folder(folder_path: &Path, prefered_text_editor: Option<TextEditor>)
             }
         }
         Some(TextEditor::Emacs) => {
-            let is_emacs = which::which("emacsclient").is_ok();
-            if is_emacs {
-                let res = Command::new("emacsclient")
+            let path = which::which("emacsclient");
+            if let Ok(emacsclient_path) = path {
+                let res = Command::new(emacsclient_path)
                     .args([absolute_path.as_str()])
                     .spawn();
                 res.is_ok()

--- a/editor/src/editorinterface/extra/openfileatline.rs
+++ b/editor/src/editorinterface/extra/openfileatline.rs
@@ -143,9 +143,13 @@ pub fn open_folder(folder_path: &Path, prefered_text_editor: Option<TextEditor>)
             }
         }
         Some(TextEditor::VSCode) => {
-            let is_code = which::which("code").is_ok();
-            if is_code {
-                let res = Command::new("code").args([absolute_path.as_str()]).spawn();
+            let path = which::which("code");
+            println!("path: {:?}", path);
+            if let Ok(code_path) = path {
+                let res = Command::new(code_path)
+                    .args([absolute_path.as_str()])
+                    .spawn();
+                println!("res: {:?}", res);
                 res.is_ok()
             } else {
                 false

--- a/runtime/src/io/localfs.rs
+++ b/runtime/src/io/localfs.rs
@@ -4,6 +4,7 @@ use std::cell::Cell;
 use std::cell::RefCell;
 #[cfg(target_os = "emscripten")]
 use std::collections::HashMap;
+use std::path::Path;
 
 use crate::io::fs::FileSystem;
 use crate::io::fs::ReadOnlyFileSystem;
@@ -22,7 +23,7 @@ impl ReadOnlyFileSystem for LocalFileSystem {
         let path = Path::new(filename);
 
         if let Ok(canonical) = path.canonicalize() {
-            let canonical_with_slash = canonical.to_string_lossy().replace("\\", "/");
+            let canonical_with_slash = normalize_path(&canonical);
             let ends_with = canonical_with_slash.ends_with(filename);
 
             if !ends_with {
@@ -61,6 +62,10 @@ impl FileSystem for LocalFileSystem {
             }
         }
     }
+}
+
+pub fn normalize_path(path: &Path) -> String {
+    path.to_string_lossy().replace("\\", "/")
 }
 
 #[cfg(target_os = "emscripten")]


### PR DESCRIPTION

Bugs fixed:

- On windows, the recently opened project did not work
- On some systems, we struggled to open a folder in the prefered text editor
- VSCode was shown as the preferred editor even when none were selected